### PR TITLE
Revert "Differentiate files and folders in `file_list`"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,3 @@
 ## Unreleased (master)
 ### Fixes
 * Correctly handle more than 30 branches\tags
-* Differentiate files and folders in `file_list`

--- a/lib/onlyoffice_github_helper/github_client/file_list.rb
+++ b/lib/onlyoffice_github_helper/github_client/file_list.rb
@@ -2,11 +2,9 @@ module OnlyofficeGithubHelper
   # Module for working with file list
   module FileList
     def file_list(repo, refs: 'master')
-      Octokit.tree(repo, refs, recursive: true).tree.map do |file|
-        path = file.path
-        path << '/' if file.type == 'tree'
-        path
-      end
+      Octokit.tree(repo, refs, recursive: true).tree
+             .reject { |elem| elem.type == 'tree' }
+             .map(&:path)
     end
   end
 end

--- a/spec/file_list_spec.rb
+++ b/spec/file_list_spec.rb
@@ -16,9 +16,4 @@ describe OnlyofficeGithubHelper::FileList do
     expect(github.file_list('ONLYOFFICE/ooxml_parser'))
       .to include('lib/ooxml_parser/version.rb')
   end
-
-  it 'Check that file list contains folders' do
-    expect(github.file_list('ONLYOFFICE/ooxml_parser'))
-      .to include('lib/')
-  end
 end


### PR DESCRIPTION
Reverts onlyoffice-testing-robot/onlyoffice_github_helper#3

Have tought about it - this data is redundant