### PR TITLE
Add ruby 3.0 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
-        ruby: 2.7
+        ruby: [2.7]
         allow-failures: [false]
         include:
           - ruby: head

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,10 +6,10 @@ jobs:
     continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
-        ruby: [2.7, 3.0]
+        ruby: 2.7
         allow-failures: [false]
         include:
-          - ruby: head
+          - ruby: [3.0, head]
             allow-failures: true
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,9 @@ jobs:
         ruby: 2.7
         allow-failures: [false]
         include:
-          - ruby: [3.0, head]
+          - ruby: 3.0
+            allow-failures: true
+          - ruby: head
             allow-failures: true
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,8 +9,6 @@ jobs:
         ruby: 2.7
         allow-failures: [false]
         include:
-          - ruby: 3.0
-            allow-failures: true
           - ruby: head
             allow-failures: true
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 * Freeze all dependencies versions in `Gemfile.lock`
 * Add `markdownlint` check in CI
 * Add `rubocop` check in CI
-* Add `ruby-3.0` to CI and allow failures
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Freeze all dependencies versions in `Gemfile.lock`
 * Add `markdownlint` check in CI
 * Add `rubocop` check in CI
+* Add `ruby-3.0` to CI and allow failures
 
 ### Changes
 


### PR DESCRIPTION
Currently failures are allowed, since codecov is not support on ruby 3.0